### PR TITLE
タスク一覧取得機能の実装

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -1,24 +1,40 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from schemas.tasks.request import TaskCreate
-from schemas.tasks.response import CreateTaskResponse
+from schemas.tasks.response import TaskResponse
 from usecase import tasks
 
 from dependencies import get_db
+
+from typing import List
 
 router = APIRouter(
     prefix="/api/v1/tasks",
     tags=["tasks"],
 )
 
-@router.post("/add", response_model=CreateTaskResponse)
+@router.get("/", response_model=List[TaskResponse])
+async def read_tasks(db: AsyncSession = Depends(get_db)):
+    res = tasks.get_tasks(db)
+    return [
+        TaskResponse(
+            task_id=task.id,
+            title=task.title,
+            description=task.description,
+            is_done=task.is_done,
+            created_at=task.created_at,
+            updated_at=task.updated_at
+        ) for task in res
+    ]
+
+@router.post("/add", response_model=TaskResponse)
 async def create_task(task_body: TaskCreate, db: AsyncSession = Depends(get_db)):
     res = tasks.create_task(db, task_body)
-    return CreateTaskResponse(
+    return TaskResponse(
         task_id=res.id,
         title=res.title,
         description=res.description,
         is_done=res.is_done,
         created_at=res.created_at,
         updated_at=res.updated_at
-        )
+    )

--- a/backend/schemas/tasks/response.py
+++ b/backend/schemas/tasks/response.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-class CreateTaskResponse(BaseModel):
+class TaskResponse(BaseModel):
     task_id: UUID
     title: str
-    description: str
+    description: Optional[str]
     is_done: bool
     created_at: datetime
     updated_at: datetime | None

--- a/backend/usecase/tasks.py
+++ b/backend/usecase/tasks.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-
 from sqlalchemy.ext.asyncio import AsyncSession
-
 from models.task import Task
 from schemas.tasks.request import TaskCreate
 
@@ -13,3 +11,6 @@ def create_task(
     db.commit()
     db.refresh(task)
     return task
+
+def get_tasks(db: AsyncSession) -> list[Task]:
+    return db.query(Task).all()

--- a/frontend/src/app/api/tasks/index.ts
+++ b/frontend/src/app/api/tasks/index.ts
@@ -9,6 +9,11 @@ export type Task = {
     updated_at: string
 }
 
+export const getTasks = async () : Promise<Task[]> => {
+    const response = await fetch(`${ORIGIN}/tasks`);
+    return response.json()
+}
+
 export const addTask = async (title: string, description: string) : Promise<Task> => {
     const response = await fetch(`${ORIGIN}/tasks/add`, {
         method: 'POST',

--- a/frontend/src/app/components/AddTaskModal/index.tsx
+++ b/frontend/src/app/components/AddTaskModal/index.tsx
@@ -7,11 +7,13 @@ export type ModalProps = {
   onSubmit: () => void;
   modalTitle: string;
   submitBtnTitle: string;
+  title: string;
+  description: string;
   setTile: React.Dispatch<React.SetStateAction<string>>;
   setDescription: React.Dispatch<React.SetStateAction<string>>;
 };
 
-export const MessageDialog = ({open, onCancel, onSubmit, setTile, setDescription, modalTitle, submitBtnTitle}: ModalProps) => {
+export const MessageDialog = ({open, onCancel, onSubmit, setTile, setDescription, modalTitle, submitBtnTitle, title, description}: ModalProps) => {
   return open && (
     <>
       <div className="fixed inset-0 bg-black bg-opacity-50 z-10" onClick={() => onCancel()}></div>
@@ -22,6 +24,7 @@ export const MessageDialog = ({open, onCancel, onSubmit, setTile, setDescription
         <input
           className='w-full h-10 border border-gray-300 rounded-md mb-5 px-3'
           placeholder='買い物'
+          value={title}
           onChange={(e) => setTile(e.target.value)}
         />
 
@@ -29,6 +32,7 @@ export const MessageDialog = ({open, onCancel, onSubmit, setTile, setDescription
         <textarea
           className='w-full h-20 border border-gray-300 rounded-md mb-5 px-3'
           placeholder='牛乳を買う'
+          value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
 

--- a/frontend/src/app/components/TaskTable/index.tsx
+++ b/frontend/src/app/components/TaskTable/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Task } from '../../api/tasks';
+
+type TaskTableProps = {
+    tasks: Task[];
+    handleOpenModal: (task_id: string) => void;
+    handleDelete: (task_id: string) => void;
+    setIsEdit: (isEdit: boolean) => void;
+}
+
+export const TaskTable = ({ tasks, handleOpenModal, handleDelete, setIsEdit }: TaskTableProps) => {
+    return (
+        <table className="table-auto w-full border-collapse border border-gray-200">
+          <thead>
+            <tr>
+              <th className="text-left border-t border-b border-l border-r border-gray-200 px-4 py-2">タイトル</th>
+              <th className="text-left border-t border-b border-l border-r border-gray-200 px-4 py-2">詳細</th>
+              <th className="border-t border-b border-l border-r border-gray-200 px-4 py-2">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((task, index) => (
+              <tr key={index}>
+                <td className="text-left border-t border-b border-l border-r border-gray-200 px-4 py-2">{task.title}</td>
+                <td className="text-left border-t border-b border-l border-r border-gray-200 px-4 py-2">{task.description}</td>
+                <td className="border-t border-b border-l border-r border-gray-200 px-4 py-2">
+                  <button onClick={() => {
+                    setIsEdit(true);
+                    handleOpenModal(task.task_id);
+                  }} className="text-blue-500 mr-2">編集</button>
+                  <button onClick={() => handleDelete(task.task_id)} className="text-red-500">削除</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+    )
+}

--- a/frontend/src/app/hooks/useAddTask.ts
+++ b/frontend/src/app/hooks/useAddTask.ts
@@ -4,9 +4,10 @@ import { addTask } from '../api/tasks';
 type AddTaskProps = {
     title: string;
     description: string;
+    renewTasks: () => void;
 }
 
-export const useAddTask = ({ title, description }: AddTaskProps) => {
+export const useAddTask = ({ title, description, renewTasks }: AddTaskProps) => {
 
     const handleAddTask = () => {
         addTask(title, description).then((data) => {
@@ -22,6 +23,7 @@ export const useAddTask = ({ title, description }: AddTaskProps) => {
                     theme: "light",
                     transition: Bounce,
                 });
+                renewTasks();
             }
         }).catch((error) => {
             console.error('Error:', error);

--- a/frontend/src/app/hooks/useGetTasks.ts
+++ b/frontend/src/app/hooks/useGetTasks.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { getTasks, Task } from "../api/tasks";
+
+export const useGetTasks = () => {
+    const [tasks, setTasks] = useState<Task[]>([]);
+
+    useEffect(() => {
+        getTasks().then((data) => {
+            setTasks(data);
+        });
+    }, [setTasks]);
+
+    const handleGetTasks = async () => {
+        getTasks().then((data) => {
+            setTasks(data);
+        });
+    };
+
+    return { tasks, handleGetTasks };
+}

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -5,6 +5,9 @@ import { MessageDialog } from '../components/AddTaskModal';
 import AddButton from '../components/Buttons/Add';
 import { useAddTask } from '../hooks/useAddTask';
 import useEditTask from '../hooks/useEditTask';
+import { useGetTasks } from '../hooks/useGetTasks';
+import { TaskTable } from '../components/TaskTable';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 export default function TaskLists() {
@@ -13,17 +16,17 @@ export default function TaskLists() {
   const [description, setDescription] = useState('');
   const [isEdit, setIsEdit] = useState(false);
 
-  const { handleAddTask } = useAddTask({ title, description });
+  const { tasks, handleGetTasks } = useGetTasks();
+  const { handleAddTask } = useAddTask({ title, description, renewTasks: handleGetTasks });
   const { editTask } = useEditTask({ title, description });
 
-  const [tasks, setTasks] = useState(['task1', 'task2', 'task3']);
-
   const handleOpenModal = (id?: string) => {
-    if(id) {
+    if (id) {
       setIsEdit(true);
-      setTitle(tasks[parseInt(id)]);
-      setDescription(tasks[parseInt(id)]);
-    }else{
+      const task = tasks.find((task) => task.task_id === id);
+      setTitle(task?.title || '');
+      setDescription(task?.description || '');
+    } else {
       setIsEdit(false);
       setTitle('');
       setDescription('');
@@ -31,14 +34,14 @@ export default function TaskLists() {
     setIsOpen(true);
   };
 
-  const handleDelete = (index: number) => {
-    setTasks(tasks.filter((_, i) => i !== index));
-  };
+  const handleDelete = (id: string) => {
+    console.log('Delete task:', id);
+  }
 
   const handleSubmit = () => {
-    if(isEdit){
+    if (isEdit) {
       editTask();
-    }else{
+    } else {
       handleAddTask();
     }
     setIsOpen(false);
@@ -51,20 +54,11 @@ export default function TaskLists() {
           <h1 className="text-2xl font-bold mb-4">タスク一覧</h1>
           <AddButton title='タスクの追加' onClick={() => handleOpenModal()} />
         </div>
-        <ul className="list-disc list-inside">
-          {tasks.map((task, index) => (
-            <li key={index} className="text-left flex justify-between items-center">
-              {task}
-              <div>
-                <button onClick={() => {
-                  setIsEdit(true);
-                  handleOpenModal(index.toString());
-                }} className="text-blue-500 mr-2">編集</button>
-                <button onClick={() => handleDelete(index)} className="text-red-500">削除</button>
-              </div>
-            </li>
-          ))}
-        </ul>
+        <TaskTable
+          tasks={tasks}
+          handleOpenModal={handleOpenModal}
+          handleDelete={handleDelete}
+          setIsEdit={setIsEdit} />
       </div>
 
       <div className="ml-6">
@@ -73,6 +67,8 @@ export default function TaskLists() {
             onSubmit={handleSubmit}
             onCancel={() => setIsOpen(false)}
             open={isOpen}
+            title={title}
+            description={description}
             setTile={setTitle}
             setDescription={setDescription}
             modalTitle={isEdit ? 'タスクの編集' : 'タスクの追加'}
@@ -84,7 +80,6 @@ export default function TaskLists() {
       <div className="fixed bottom-0 right-0 p-4">
         <ToastContainer />
       </div>
-
     </div>
   );
 }


### PR DESCRIPTION
ref: #3 

## 変更点
- バックエンド
  - タスク一覧取得用エンドポイント(GET, `/api/v1/tasks/`)の実装を行いました
  - レスポンススキーマの修正を行いました
- フロントエンド
  - 一覧表示に際したUI周りの修正を行いました
  - バックエンドとのつなぎこみを実施しました

## 残タスク
- 編集・削除機能の実装(次回PRでそれぞれ対応予定)
- ユーザ認証周りで使用しているRoleをコメントアウトしたため、後に確認&実装必須