### PR TITLE
タスク編集機能の実装

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -38,3 +38,15 @@ async def create_task(task_body: TaskCreate, db: AsyncSession = Depends(get_db))
         created_at=res.created_at,
         updated_at=res.updated_at
     )
+
+@router.put("/edit/{task_id}", response_model=TaskResponse)
+async def update_task(task_id: str, task_body: TaskCreate, db: AsyncSession = Depends(get_db)):
+    res = tasks.update_task(db, task_id, task_body)
+    return TaskResponse(
+        task_id=res.id,
+        title=res.title,
+        description=res.description,
+        is_done=res.is_done,
+        created_at=res.created_at,
+        updated_at=res.updated_at
+    )

--- a/backend/usecase/tasks.py
+++ b/backend/usecase/tasks.py
@@ -14,3 +14,12 @@ def create_task(
 
 def get_tasks(db: AsyncSession) -> list[Task]:
     return db.query(Task).all()
+
+def update_task(db: AsyncSession, task_id: int, task_create: TaskCreate) -> Task:
+    task = db.query(Task).filter(Task.id == task_id).first()
+    task.title = task_create.title
+    task.description = task_create.description
+    task.updated_at = datetime.now()
+    db.commit()
+    db.refresh(task)
+    return task

--- a/frontend/src/app/api/tasks/index.ts
+++ b/frontend/src/app/api/tasks/index.ts
@@ -24,3 +24,15 @@ export const addTask = async (title: string, description: string) : Promise<Task
     });
     return response.json()
 }
+
+export const editTask = async (task_id: string, title: string, description: string) : Promise<Task> => {
+    const response = await fetch(`${ORIGIN}/tasks/edit/${task_id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title, description }),
+    });
+    return response.json()
+}
+

--- a/frontend/src/app/components/TaskTable/index.tsx
+++ b/frontend/src/app/components/TaskTable/index.tsx
@@ -5,10 +5,9 @@ type TaskTableProps = {
     tasks: Task[];
     handleOpenModal: (task_id: string) => void;
     handleDelete: (task_id: string) => void;
-    setIsEdit: (isEdit: boolean) => void;
 }
 
-export const TaskTable = ({ tasks, handleOpenModal, handleDelete, setIsEdit }: TaskTableProps) => {
+export const TaskTable = ({ tasks, handleOpenModal, handleDelete}: TaskTableProps) => {
     return (
         <table className="table-auto w-full border-collapse border border-gray-200">
           <thead>
@@ -25,7 +24,6 @@ export const TaskTable = ({ tasks, handleOpenModal, handleDelete, setIsEdit }: T
                 <td className="text-left border-t border-b border-l border-r border-gray-200 px-4 py-2">{task.description}</td>
                 <td className="border-t border-b border-l border-r border-gray-200 px-4 py-2">
                   <button onClick={() => {
-                    setIsEdit(true);
                     handleOpenModal(task.task_id);
                   }} className="text-blue-500 mr-2">編集</button>
                   <button onClick={() => handleDelete(task.task_id)} className="text-red-500">削除</button>

--- a/frontend/src/app/hooks/useEditTask.ts
+++ b/frontend/src/app/hooks/useEditTask.ts
@@ -1,17 +1,26 @@
+import { useState } from "react";
+import { editTask } from "../api/tasks";
+
 type EditTaskProps = {
     title: string;
     description: string;
+    renewTasks: () => void;
 }
 
-const useEditTask = ({ title, description }: EditTaskProps) => {
+const useEditTask = ({ title, description, renewTasks }: EditTaskProps) => {
+    const [editTaskId, setEditTaskId] = useState<string>('');
     
-    const editTask = () => {
-        console.log('title:', title);
-        console.log('description:', description);
+    const handleEditTask = () => {
+        editTask(editTaskId, title, description).then(() => {
+            renewTasks();
+            setEditTaskId('');
+        });
     }
     
     return {
-        editTask
+        editTaskId,
+        setEditTaskId,
+        handleEditTask
     };
 }
 

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -14,20 +14,18 @@ export default function TaskLists() {
   const [isOpen, setIsOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [isEdit, setIsEdit] = useState(false);
 
   const { tasks, handleGetTasks } = useGetTasks();
   const { handleAddTask } = useAddTask({ title, description, renewTasks: handleGetTasks });
-  const { editTask } = useEditTask({ title, description });
+  const { handleEditTask, editTaskId, setEditTaskId } = useEditTask({ title, description, renewTasks: handleGetTasks });
 
   const handleOpenModal = (id?: string) => {
     if (id) {
-      setIsEdit(true);
+      setEditTaskId(id);
       const task = tasks.find((task) => task.task_id === id);
       setTitle(task?.title || '');
       setDescription(task?.description || '');
     } else {
-      setIsEdit(false);
       setTitle('');
       setDescription('');
     }
@@ -39,8 +37,8 @@ export default function TaskLists() {
   }
 
   const handleSubmit = () => {
-    if (isEdit) {
-      editTask();
+    if (editTaskId) {
+      handleEditTask();
     } else {
       handleAddTask();
     }
@@ -48,8 +46,8 @@ export default function TaskLists() {
   };
 
   return (
-    <div className="flex justify-center items-center h-screen bg-gray-100">
-      <div className="w-1/2 text-center bg-white p-6 rounded-lg shadow-lg">
+    <div className="flex justify-center items-center bg-gray-100 text-gray-800 h-screen">
+      <div className="w-1/2 text-center bg-white p-6 rounded-lg shadow-lg overflow-y-auto max-h-full">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold mb-4">タスク一覧</h1>
           <AddButton title='タスクの追加' onClick={() => handleOpenModal()} />
@@ -58,7 +56,7 @@ export default function TaskLists() {
           tasks={tasks}
           handleOpenModal={handleOpenModal}
           handleDelete={handleDelete}
-          setIsEdit={setIsEdit} />
+        />
       </div>
 
       <div className="ml-6">
@@ -71,8 +69,8 @@ export default function TaskLists() {
             description={description}
             setTile={setTitle}
             setDescription={setDescription}
-            modalTitle={isEdit ? 'タスクの編集' : 'タスクの追加'}
-            submitBtnTitle={isEdit ? '保存' : '追加'}
+            modalTitle={editTaskId ? 'タスクの編集' : 'タスクの追加'}
+            submitBtnTitle={editTaskId ? '保存' : '追加'}
           />
         )}
       </div>


### PR DESCRIPTION
ref: #5 

## 変更点
- バックエンド
  - タスク編集用エンドポイント(PUT, `/api/v1/tasks/edit`)の実装を行いました
- フロントエンド
  - 編集を可能にするためのUI周りの修正を行いました
  - バックエンドとのつなぎこみを実施しました

## 残タスク
- 削除機能の実装(次回PRでそれぞれ対応予定)
- 検索機能の実装
- タスクフィルタリング機能の実装
- ユーザ認証周りで使用しているRoleをコメントアウトしたため、後に確認&実装必須