### PR TITLE
タスク削除機能の実装

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -50,3 +50,15 @@ async def update_task(task_id: str, task_body: TaskCreate, db: AsyncSession = De
         created_at=res.created_at,
         updated_at=res.updated_at
     )
+
+@router.delete("/delete/{task_id}", response_model=TaskResponse)
+async def delete_task(task_id: str, db: AsyncSession = Depends(get_db)):
+    res = tasks.delete_task(db, task_id)
+    return TaskResponse(
+        task_id=res.id,
+        title=res.title,
+        description=res.description,
+        is_done=res.is_done,
+        created_at=res.created_at,
+        updated_at=res.updated_at
+    )

--- a/backend/usecase/tasks.py
+++ b/backend/usecase/tasks.py
@@ -23,3 +23,9 @@ def update_task(db: AsyncSession, task_id: int, task_create: TaskCreate) -> Task
     db.commit()
     db.refresh(task)
     return task
+
+def delete_task(db: AsyncSession, task_id: int) -> Task:
+    task = db.query(Task).filter(Task.id == task_id).first()
+    db.delete(task)
+    db.commit()
+    return task

--- a/frontend/src/app/api/tasks/index.ts
+++ b/frontend/src/app/api/tasks/index.ts
@@ -36,3 +36,10 @@ export const editTask = async (task_id: string, title: string, description: stri
     return response.json()
 }
 
+
+export const deleteTask = async (task_id: string) : Promise<Task> => {
+    const response = await fetch(`${ORIGIN}/tasks/delete/${task_id}`, {
+        method: 'DELETE',
+    });
+    return response.json()
+}

--- a/frontend/src/app/hooks/useDeleteTask.ts
+++ b/frontend/src/app/hooks/useDeleteTask.ts
@@ -1,0 +1,45 @@
+import { toast, Bounce} from 'react-toastify';
+import { deleteTask } from "../api/tasks";
+
+type DeleteTaskProps = {
+    renewTasks: () => void;
+}
+
+export const useDeleteTask = ({ renewTasks }: DeleteTaskProps) => {
+    
+    const handleDeleteTask = (deleteTaskId: string) => {
+        deleteTask(deleteTaskId).then((data) => {
+            if(data.task_id){
+                toast.success('タスクを削除しました', {
+                    position: "top-right",
+                    autoClose: 5000,
+                    hideProgressBar: false,
+                    closeOnClick: true,
+                    pauseOnHover: true,
+                    draggable: true,
+                    progress: undefined,
+                    theme: "light",
+                    transition: Bounce,
+                });
+                renewTasks();
+            }
+        }).catch((error) => {
+            console.error(error);
+            toast.error('タスクの削除に失敗しました', {
+                position: "top-right",
+                autoClose: 5000,
+                hideProgressBar: false,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+                theme: "light",
+                transition: Bounce,
+            });
+        });
+    }
+
+    return {
+        handleDeleteTask
+    };
+}

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -9,6 +9,7 @@ import { useGetTasks } from '../hooks/useGetTasks';
 import { TaskTable } from '../components/TaskTable';
 
 import 'react-toastify/dist/ReactToastify.css';
+import { useDeleteTask } from '../hooks/useDeleteTask';
 
 export default function TaskLists() {
   const [isOpen, setIsOpen] = useState(false);
@@ -18,11 +19,12 @@ export default function TaskLists() {
   const { tasks, handleGetTasks } = useGetTasks();
   const { handleAddTask } = useAddTask({ title, description, renewTasks: handleGetTasks });
   const { handleEditTask, editTaskId, setEditTaskId } = useEditTask({ title, description, renewTasks: handleGetTasks });
+  const { handleDeleteTask } = useDeleteTask({ renewTasks: handleGetTasks });
 
-  const handleOpenModal = (id?: string) => {
-    if (id) {
-      setEditTaskId(id);
-      const task = tasks.find((task) => task.task_id === id);
+  const handleOpenModal = (task_id?: string) => {
+    if (task_id) {
+      setEditTaskId(task_id);
+      const task = tasks.find((task) => task.task_id === task_id);
       setTitle(task?.title || '');
       setDescription(task?.description || '');
     } else {
@@ -31,10 +33,6 @@ export default function TaskLists() {
     }
     setIsOpen(true);
   };
-
-  const handleDelete = (id: string) => {
-    console.log('Delete task:', id);
-  }
 
   const handleSubmit = () => {
     if (editTaskId) {
@@ -50,12 +48,12 @@ export default function TaskLists() {
       <div className="w-1/2 text-center bg-white p-6 rounded-lg shadow-lg overflow-y-auto max-h-full">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold mb-4">タスク一覧</h1>
-          <AddButton title='タスクの追加' onClick={() => handleOpenModal()} />
+          <AddButton title='タスクの追加' onClick={handleOpenModal} />
         </div>
         <TaskTable
           tasks={tasks}
           handleOpenModal={handleOpenModal}
-          handleDelete={handleDelete}
+          handleDelete={handleDeleteTask}
         />
       </div>
 


### PR DESCRIPTION
ref: #7 

## 変更点
- バックエンド
  - タスク削除用エンドポイント(DELETE, `/api/v1/tasks/delete`)の実装を行いました
- フロントエンド
  - 編集を可能にするためのUI周りの修正を行いました
  - バックエンドとのつなぎこみを実施しました

## 残タスク
- 検索機能の実装
- タスクフィルタリング機能の実装
- ユーザ認証周りで使用しているRoleをコメントアウトしたため、後に確認&実装必須